### PR TITLE
Update Url of Icon Preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
       <li><b>Manuel Genovés</b> <br> Maintainer of <a href="https://github.com/UberWriter/uberwriter">UberWriter</a></li>
       <li><b>Michael Gratton</b> <br> Maintainer of <a href="https://gitlab.gnome.org/GNOME/Geary">Geary</a></li>
       <li><b>Tobias Bernard</b> <br> Designer of <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a> and <a href="https://gitlab.gnome.org/World/podcasts">Podcasts</a> (among others)</li>
-      <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/icon-tool">Icon Preview</a></li>
+      <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/design/icon-preview">Icon Preview</a></li>
       <li><b>The <a href="http://pitivi.org">Pitivi</a> Developers</b></li>
 
       <br>


### PR DESCRIPTION
When visiting the old Url, one gets redirected and told to update links to the new Url.

Old Url: https://gitlab.gnome.org/World/icon-tool