### PR TITLE
Update index.html to fix Pitivi link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
       <li><b>Tobias Bernard</b> <br> Designer of <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a> and <a href="https://gitlab.gnome.org/World/podcasts">Podcasts</a> (among others)</li>
       <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/design/icon-preview">Icon Preview</a></li>
       <li><b>The <a href="https://usebottles.com">Bottles</a> Developers</b></li>
-      <li><b>The <a href="https://pitivi.org">Pitivi</a> Developers</b></li>
+      <li><b>The <a href="https://www.pitivi.org">Pitivi</a> Developers</b></li>
 
       <br>
 


### PR DESCRIPTION
Fixed the link to https://www.pitivi.org (an error page appears without the "www.").