### PR TITLE
Add Graphs developers to letter

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
       <li><b>The <a href="https://usebottles.com">Bottles</a> Developers</b></li>
       <li><b>The <a href="https://pitivi.org">Pitivi</a> Developers</b></li>
       <li><b>The <a href="https://gradienceteam.github.io">Gradience</a> Developers</b></li>
+      <li><b>The <a href="https://github.com/Sjoerd1993/Graphs">Graphs</a> Developers</b></li>
 
       <br>
 


### PR DESCRIPTION
Mostly inspired by an issue with Ubuntu, where the Yaru theme clashes somewhat with the carefully chosen stylesheets for Graphs, we have decided to add our project to the open letter. Distro's that decide to override the theming of third party applications create an untestable situation. Which at best cheapen the feel of the application, and at worst kills accessibility. 
The recent success of the GNOME app ecosystem (which is doing very well) is imo partly due to LibAdwaita, and the tools that make it possible to create a nice and consistent experience within the entire GNOME desktop environment. Overriding the themes as Ubuntu does is harmful for the ecosystem in the long run.

I am not sure if there's a threshold for relevance, as we are a somewhat smaller project. But at the moment we're sitting at slightly more than 300 active installs on the Canonical Snap store, and over 6600 installs on Flathub since release in December 2021. See our project page [here.](https://github.com/Sjoerd1993/Graphs).

If it's preferred to have our names individually on the letter, that's fine by me as well by the way.