### PR TITLE
Update Graphs url

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
       <li><b>The <a href="https://usebottles.com">Bottles</a> Developers</b></li>
       <li><b>The <a href="https://pitivi.org">Pitivi</a> Developers</b></li>
       <li><b>The <a href="https://gradienceteam.github.io">Gradience</a> Developers</b></li>
-      <li><b>The <a href="https://github.com/Sjoerd1993/Graphs">Graphs</a> Developers</b></li>
+      <li><b>The <a href="https://apps.gnome.org/Graphs/">Graphs</a> Developers</b></li>
 
       <br>
 


### PR DESCRIPTION
Update the url of Graphs from the GitHub mirror to the Apps for GNOME page.