### PR TITLE
Update signature links

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,16 +108,16 @@
       <li><b>Bilal Elmoussaoui</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Authenticator">Authenticator</a>, <a href="https://gitlab.gnome.org/World/design/icon-library">Icon Library</a>, <a href="https://gitlab.gnome.org/World/design/contrast">Contrast</a> and <a href="https://gitlab.gnome.org/World/obfuscate">Obfuscate</a></li>
       <li><b>Brage Fuglseth</b> <br> Maintainer of <a href="https://github.com/bragefuglseth/keypunch">Keypunch</a> and <a href="https://apps.gnome.org/Fretboard">Fretboard</a></li>
       <li><b>Cédric Bellegarde</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/lollypop">Lollypop</a> and <a href="https://gitlab.gnome.org/GNOME/geary">Geary</a></li>
-      <li><b>Christopher Davis</b> <br> Core contributor to <a href="https://gitlab.gnome.org/GNOME/Fractal">Fractal</a></li>
-      <li><b>Daniel García Moreno</b> <br> Maintainer of <a href="https://gitlab.gnome.org/GNOME/Fractal">Fractal</a> and <a href="https://gitlab.gnome.org/danigm/timetrack">Timetrack</a></li>
+      <li><b>Christopher Davis</b> <br> Core contributor to <a href="https://gitlab.gnome.org/World/fractal">Fractal</a></li>
+      <li><b>Daniel García Moreno</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/fractal">Fractal</a> and <a href="https://gitlab.gnome.org/danigm/timetrack">Timetrack</a></li>
       <li><b>Evangelos "GeopJr" Paterakis</b> <br> Maintainer of <a href="https://tuba.geopjr.dev/">Tuba</a>, <a href="https://collision.geopjr.dev">Collision</a>, <a href="https://archives.geopjr.dev">Archives</a> and <a href="https://calligraphy.geopjr.dev">Calligraphy</a></li>
-      <li><b>Falk Alexander Seidl</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/PasswordSafe">Password Safe</a></li>
-      <li><b>Felix Häcker</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Shortwave">Shortwave</a>, <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a>, and <a href="https://gitlab.gnome.org/World/Remotely">Remotely</a></li>
+      <li><b>Falk Alexander Seidl</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/secrets">Secrets</a></li>
+      <li><b>Felix Häcker</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Shortwave">Shortwave</a>, <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a>, and <a href="https://gitlab.gnome.org/Archive/Remotely">Remotely</a></li>
       <li><b>Forever XML</b> <br> Maintainer of <a href="https://codeberg.org/foreverxml/random">Random</a></li>
       <li><b>Gianni Rosato</b> <br> Maintainer of <a href="https://github.com/gianni-rosato/aviator">Aviator</a></li>
-      <li><b>Jan Lukas Gernert</b> <br> Author of <a href="https://jangernert.github.io/FeedReader/">FeedReader</a> and <a href="https://gitlab.com/news-flash">Newsflash</a></li>
+      <li><b>Jan Lukas Gernert</b> <br> Author of <a href="https://github.com/jangernert/FeedReader/">FeedReader</a> and <a href="https://gitlab.com/news-flash">Newsflash</a></li>
       <li><b>Jordan Petridis</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/podcasts">Podcasts</a></li>
-      <li><b>Julian Sparber</b> <br> Core contributor to <a href="https://gitlab.gnome.org/GNOME/Fractal">Fractal</a>, maintainer of <a href="https://gitlab.gnome.org/jsparber/teleport">Teleport</a></li>
+      <li><b>Julian Sparber</b> <br> Core contributor to <a href="https://gitlab.gnome.org/World/fractal">Fractal</a>, maintainer of <a href="https://gitlab.gnome.org/jsparber/teleport">Teleport</a></li>
       <li><b>Lains</b> <br> Maintainer of <a href="https://github.com/lainsce/khronos">Khronos</a></li>
       <li><b>Manuel Genovés</b> <br> Maintainer of <a href="https://github.com/UberWriter/uberwriter">UberWriter</a></li>
       <li><b>Maximiliano Sandoval</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/decoder">Decoder</a>, <a href="https://gitlab.gnome.org/World/design/lorem">Lorem</a>, <a href="https://gitlab.gnome.org/World/Secrets">Secrets</a>, and <a href="https://gitlab.gnome.org/World/citations">Citations</a></li>
@@ -126,9 +126,9 @@
       <li><b>Rafael Mardojai C.M.</b> <br> Maintainer of <a href="https://github.com/rafaelmardojai/blanket">Blanket</a>, <a href="https://github.com/dialect-app/dialect">Dialect</a>, <a href="https://github.com/rafaelmardojai/share-preview">Share Preview</a> and <a href="https://github.com/rafaelmardojai/webfont-kit-generator">Webfont Kit Generator</a></li>
       <li><b>Sophie Herold</b> <br> Maintainer of <a href="https://apps.gnome.org/app/org.gnome.World.PikaBackup/">Pika Backup</a></li>
       <li><b>Tobias Bernard</b> <br> Designer of <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a> and <a href="https://gitlab.gnome.org/World/podcasts">Podcasts</a> (among others)</li>
-      <li><b>Vladimir Vaskov</b> <br> Maintainer of <a href="https://github.com/Rirusha/Cassette/">Cassette</a></li>
-      <li><b>Vojtěch Perník</b> <br> Maintainer of <a href="https://gitlab.gnome.org/pervoj/Blurble">Blurble</a></li>
-      <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/design/icon-preview">App Icon Preview</a></li>
+      <li><b>Vladimir Vaskov</b> <br> Maintainer of <a href="https://gitlab.gnome.org/Rirusha/Cassette/">Cassette</a></li>
+      <li><b>Vojtěch Perník</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Blurble">Blurble</a></li>
+      <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/design/app-icon-preview">App Icon Preview</a></li>
       <li><b>The <a href="https://usebottles.com">Bottles</a> Developers</b></li>
       <li><b>The <a href="https://gradienceteam.github.io">Gradience</a> Developers</b></li>
       <li><b>The <a href="https://apps.gnome.org/Graphs/">Graphs</a> Developers</b></li>


### PR DESCRIPTION
Update several of the links to projects in existing signatures

- The website for Feed Reader is no longer available
- Password Safe has rebranded to Secrets
- Several projects have moved to a different location