### PR TITLE
Update Constrict URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
       <li><b>Tobias Bernard</b> <br> Designer of <a href="https://gitlab.gnome.org/World/Fragments">Fragments</a> and <a href="https://gitlab.gnome.org/World/podcasts">Podcasts</a> (among others)</li>
       <li><b>Vladimir Vaskov</b> <br> Maintainer of <a href="https://gitlab.gnome.org/Rirusha/Cassette/">Cassette</a></li>
       <li><b>Vojtěch Perník</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Blurble">Blurble</a></li>
-      <li><b>Wartybix</b> <br> Maintainer of <a href="https://github.com/Wartybix/Constrict">Constrict</a></li>
+      <li><b>Wartybix</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/Constrict">Constrict</a></li>
       <li><b>Zander Brown</b> <br> Maintainer of <a href="https://gitlab.gnome.org/World/design/app-icon-preview">App Icon Preview</a></li>
       <li><b>The <a href="https://usebottles.com">Bottles</a> Developers</b></li>
       <li><b>The <a href="https://gradienceteam.github.io">Gradience</a> Developers</b></li>


### PR DESCRIPTION
The old URL is now just a read-only mirror.